### PR TITLE
Change License ISC to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "keywords": [],
   "author": "Yoshua Wuyts <yoshuawuyts@gmail.com>",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "rethinkdb": "^2.3.2"
   }


### PR DESCRIPTION
I changed license ISC to MIT in package.json because you set `[MIT](https://tldrlegal.com/license/mit-license)` in description.

Is there any reason ?
